### PR TITLE
Major updates for AzureML Metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ venv:
 # Install requirements
 install: requirements.txt venv
 	source venv/bin/activate && pip install -r $<
+	source venv/bin/activate && pip install --upgrade requests
 
 # Run unit tests
 test: venv

--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ TensorBoard charts every 5 seconds unless `--offline` is used.
     marian-tensorboard -f path/to/train.log [-t tb azureml]
 
 Then on Azure Machine Learning VM go to the __Metrics__ tab or start a
-TensorBoard server under the __Endpoints__ tab. Using `-t tb azureml` will try
-to set `--work-dir` automatically for the TensorBoard that is run internally at
-Azure ML and prevent the script from starting own instance.
+TensorBoard server under the __Endpoints__ tab.
+
+Note that logging into Azure ML Metrics is automatically enabled if Azure ML
+Run ID is detected. Specify `-t azureml` to disable TensorBoard logging.
+If Azure ML is enabled, the script will not start an own TensorBoard server
+instance.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ TensorBoard charts every 5 seconds unless `--offline` is used.
 
 ### Azure ML
 
-    marian-tensorboard -f path/to/train.log [--azureml]
+    marian-tensorboard -f path/to/train.log [-t tb azureml]
 
 Then on Azure Machine Learning VM go to the __Metrics__ tab or start a
-TensorBoard server under the __Endpoints__ tab. Using `--azureml` will try to
-set `--work-dir` automatically for the TensorBoard that is run internally at
+TensorBoard server under the __Endpoints__ tab. Using `-t tb azureml` will try
+to set `--work-dir` automatically for the TensorBoard that is run internally at
 Azure ML and prevent the script from starting own instance.
 
 ## Contributors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 azureml-core
+azureml-mlflow
 black
+mlflow
 pytest
 tensorboard
 tensorboardX

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-azureml-core
-azureml-mlflow
-black
-mlflow
-pytest
 tensorboard
 tensorboardX
+azureml-core
+mlflow
+azureml-mlflow
+black
+pytest

--- a/src/marian_tensorboard/marian_tensorboard.py
+++ b/src/marian_tensorboard/marian_tensorboard.py
@@ -249,6 +249,8 @@ class MLFlowTrackingWriter(LogWriter):
             logger.warning("Could not autolog MLflow or extract its run ID")
 
     def write(self, type, time, update, metric, value):
+        import mlflow
+
         if type == "scalar":
             mlflow.log_metric(metric, value, step=update)
         elif type == "text":
@@ -339,6 +341,8 @@ class ServiceExit(Exception):
 
 def main():
     args = parse_user_args()
+
+    logger.info(f"Enabled tools: {', '.join(args.tool)}")
 
     # Setup signal handling
     def service_shutdown(signum, frame):

--- a/src/marian_tensorboard/marian_tensorboard.py
+++ b/src/marian_tensorboard/marian_tensorboard.py
@@ -28,13 +28,15 @@ def get_marian_tensorboard_version():
 try:
     from .version import __version__ as VERSION
 except ImportError:
-    # The relative import will not work when calling this script directly
-    # during development, so extract the version from the file
+    # Extract the version number from the file as a backup - the relative
+    # import will not work when calling the script directly during development.
     # Note that adding the script directory to PYTHONPATH and importing version
     # as a module breaks launching TensorBoard server. TODO: debug and fix
     VERSION = get_marian_tensorboard_version()
 
-UPDATE_FREQ = 10  # Monitoring for updates in log files every this number of seconds
+# Monitoring for updates in log files every this number of seconds. Note that
+# it also determines length of gentle script exit
+UPDATE_FREQ = 10
 
 # Setup logger suppressing logging from external modules
 logger = logging.getLogger("marian-tensorboard")

--- a/src/marian_tensorboard/marian_tensorboard.py
+++ b/src/marian_tensorboard/marian_tensorboard.py
@@ -464,10 +464,12 @@ def parse_user_args():
     if args.tool is None:
         args.tool = []
 
-    # Set azureml automatically if running on Azure ML
+    # Add azureml automatically if running on Azure ML
     azureml_run_id = os.getenv("AZUREML_RUN_ID", None)
     if azureml_run_id:
         args.tool.append('azureml')
+        # Do not start the server on Azure ML if automatically detected
+        args.port = 0
 
     if 'azureml' in args.tool or 'mlflow' in args.tool:
         # Try to set TensorBoard logdir to the one set on Azure ML

--- a/src/marian_tensorboard/marian_tensorboard.py
+++ b/src/marian_tensorboard/marian_tensorboard.py
@@ -241,7 +241,12 @@ class MLFlowTrackingWriter(LogWriter):
         import mlflow
 
         logger.info("Autologging to MLflow...")
-        mlflow.autolog()
+        try:
+            mlflow.autolog()
+            run_id = mlflow.active_run().info.run_id
+            logger.info(f"MLflow RunID: {run_id}")
+        except:
+            logger.warning("Could not autolog MLflow or extract its run ID")
 
     def write(self, type, time, update, metric, value):
         if type == "scalar":
@@ -427,9 +432,7 @@ def parse_user_args():
         help="set visualization tools: tb, azureml, mlflow, default: tb",
     )
     parser.add_argument(
-        "-w",
-        "--work-dir",
-        help="TensorBoard logging directory, default: logdir",
+        "-w", "--work-dir", help="TensorBoard logging directory, default: logdir"
     )
     parser.add_argument(
         "-p",

--- a/src/marian_tensorboard/marian_tensorboard.py
+++ b/src/marian_tensorboard/marian_tensorboard.py
@@ -246,11 +246,9 @@ class MLFlowTrackingWriter(LogWriter):
             run_id = mlflow.active_run().info.run_id
             logger.info(f"MLflow RunID: {run_id}")
         except:
-            logger.warning("Could not autolog MLflow or extract its run ID")
+            logger.warning("Could not autolog or extract MLflow run ID")
 
     def write(self, type, time, update, metric, value):
-        import mlflow
-
         if type == "scalar":
             mlflow.log_metric(metric, value, step=update)
         elif type == "text":

--- a/src/marian_tensorboard/marian_tensorboard.py
+++ b/src/marian_tensorboard/marian_tensorboard.py
@@ -225,11 +225,29 @@ class AzureMLMetricsWriter(LogWriter):
         from azureml.core import Run
 
         self.writer = Run.get_context()
-        logger.info("Logging to AzureML Metrics...")
+        logger.info("Logging to Azure ML Metrics...")
 
     def write(self, type, time, update, metric, value):
         if type == "scalar":
             self.writer.log_row(metric, x=update, y=value)
+        else:
+            pass
+
+
+class MLFlowTrackingWriter(LogWriter):
+    """Writing logs for MLflow Tracking."""
+
+    def __init__(self):
+        import mlflow
+
+        logger.info("Autologging to MLflow...")
+        mlflow.autolog()
+
+    def write(self, type, time, update, metric, value):
+        if type == "scalar":
+            mlflow.log_metric(metric, value, step=update)
+        elif type == "text":
+            mlflow.log_param(metric, value)
         else:
             pass
 


### PR DESCRIPTION
Changes:
- Added `--tool` option for choosing logging into TensorBoard or AzureML or both
- Removed `--azureml` option
- Setting `--port 0` will skip starting a local TensorBoard server
- Fixed a bug with loading version number when calling the script directly